### PR TITLE
Resolved error with Docker accessing CDI in notebook.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ cover/
 
 # Notebook scratchpad
 .virtual_documents
+
+# Cursor
+.cursor/

--- a/notebooks/launchable_pinecone.ipynb
+++ b/notebooks/launchable_pinecone.ipynb
@@ -375,9 +375,17 @@
     "    print(\"A100 detected. Configuring to use GPUs 1,2...\")\n",
     "    update_gpu_config(\"1,2\")\n",
     "else:\n",
-    "    # Default: H100 or other multi-GPU setup uses GPU 1\n",
-    "    print(\"Multi-GPU system detected. Using default GPU 1 configuration...\")\n",
-    "    print(\"No changes needed to .env file.\")"
+    "    # For multi-GPU systems, use GPU 0 as safe default to avoid CDI errors\n",
+    "    # GPU 0 is guaranteed to exist, while GPU 1 might not be accessible via CDI\n",
+    "    if gpu_count > 1:\n",
+    "        print(f\"Multi-GPU system detected ({gpu_count} GPUs).\")\n",
+    "        print(\"⚠️  Using GPU 0 as safe default to avoid CDI device errors.\")\n",
+    "        print(\"   If you need to use a specific GPU, set LLM_MS_GPU_ID in deploy/compose/.env\")\n",
+    "        update_gpu_config(\"0\")\n",
+    "    else:\n",
+    "        # Fallback: use GPU 0 if count is unexpected\n",
+    "        print(\"⚠️  Unexpected GPU configuration. Using GPU 0 as safe default...\")\n",
+    "        update_gpu_config(\"0\")"
    ]
   },
   {


### PR DESCRIPTION
## Problem

When deploying NIMS containers on systems with CDI (Container Device Interface) enabled, Docker Compose attempts to access GPU 1 using CDI format (`nvidia.com/gpu=1`). This fails with the error:

```bash
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: could not apply required modification to OCI specification: error modifying OCI spec: failed to inject CDI devices: unresolvable CDI devices nvidia.com/gpu=1: unknown
```

The root cause is that `LLM_MS_GPU_ID` defaults to `1` in the compose configuration, but:
- On single-GPU systems, only GPU 0 exists
- On multi-GPU systems, GPU 1 may not be registered/accessible via CDI
- The notebook's GPU detection logic only updated `LLM_MS_GPU_ID` for single-GPU systems, leaving multi-GPU systems with the problematic default

## Solution

Updated the GPU detection and configuration logic in `launchable_pinecone.ipynb` to:

1. **Always set a valid GPU ID**: Modified the multi-GPU detection branch to explicitly set `LLM_MS_GPU_ID=0` instead of relying on the default value of `1`
2. **Use GPU 0 as safe default**: GPU 0 is guaranteed to exist on all systems, avoiding CDI resolution errors
3. **Added fallback handling**: Added logic to handle unexpected GPU configurations by defaulting to GPU 0

The fix ensures that `LLM_MS_GPU_ID` and `NEMORETRIEVER_PARSE_MS_GPU_ID` are always set to a valid GPU ID that exists on the system, preventing CDI device resolution errors during container startup.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

1. **Single GPU system**: Verify that `LLM_MS_GPU_ID` is set to `0` and containers start successfully
2. **Multi-GPU system (non-A100)**: Verify that `LLM_MS_GPU_ID` is set to `0` instead of defaulting to `1`, and containers start without CDI errors
3. **A100 system**: Verify that `LLM_MS_GPU_ID` is set to `1,2` as before (no change to A100 logic)
4. **Container startup**: Run the notebook cell that starts NIMS containers and confirm all containers start successfully without CDI device errors
5. **Manual override**: Verify that users can still manually set `LLM_MS_GPU_ID` in `deploy/compose/.env` if they need a specific GPU

**Validation steps:**
- Run the GPU detection cell in `launchable_pinecone.ipynb`
- Check that `deploy/compose/.env` contains `LLM_MS_GPU_ID=0` (or appropriate value based on system)
- Execute the NIMS container startup cell
- Verify all containers start successfully: `docker ps` should show all NIMS containers in "Up" or "healthy" status